### PR TITLE
Cleaning up beta remarks

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -40,14 +40,14 @@
 
 
 <p style="text-align:left;font-size:16px;line-height:35px;">
-Welcome to the Travis CI Beta Integration with Perforce and Subversion (SVN)!
+Welcome to the Travis CI Integration with Perforce and Subversion (SVN)!
 </p>
 
 <p style="margin-bottom:4px;text-align:left;color:#333333;">
 Travis CI is a quick, simple, and reliable cloud CI/CD solution that gives organizations more control over their virtual machines. Now, the power of Travis CI is available to users of Perforce and SVN repositories.
 </p>
 <p style="margin-bottom:30px;text-align:left;color:#333333;">
-This integration relies on a new Travis CI “VCS Proxy'' that sits between your Perforce/SVN repositories and Travis CI itself. The steps in this email explain how you can set up your VCS Proxy account. (Note: You received this email because a request was made to enroll <i><%= @email %></i> in the Beta program.) 
+This integration relies on a new Travis CI “VCS Proxy" that sits between your Perforce/SVN repositories and Travis CI itself. The steps in this email explain how you can set up your VCS Proxy account. (Note: You received this email because an account was created in "VCS Proxy" for this email address.) 
 </p>
 
 <p style="margin-bottom:4px;text-align:left;color:#333333;">
@@ -64,7 +64,7 @@ Complete the following steps to set up a Travis CI account and connect it to the
 </p>
 
 <p style="margin-bottom:4px;text-align:left;color:#333333;">
-3. Next, go to the <a href="<%= @travisci_link %>" target="_blank">Travis CI Beta</a> site and click the ‘Sign in’ button in the top right corner
+3. Next, go to the <a href="<%= @travisci_link %>" target="_blank">Travis CI VCS</a> site and click the ‘Sign in’ button in the top right corner
 </p>
 
 <p style="margin-bottom:4px;text-align:left;color:#333333;">
@@ -85,20 +85,15 @@ Complete the following steps to set up a Travis CI account and connect it to the
 
 <br>
 <p style="text-align:left;margin-bottom:4px">
-As a final step, you will need to connect your Assembla repositories to the Travis CI VCS Proxy. To accomplish this, please follow the instructions found in our <a href="https://docs.travis-ci.com/user/travis-ci-vcs-proxy" target="_blank">Documentation</a>
+As a final step, you will need to connect your repositories to the Travis CI VCS Proxy. To accomplish this, please follow the instructions found in our <a href="https://docs.travis-ci.com/user/travis-ci-vcs-proxy" target="_blank">Documentation</a>
 
 <p style="text-align:left;margin-bottom:4px">
 For more details on Travis CI, we recommend starting here: <a href="https://docs.travis-ci.com/user/for-beginners" target="_blank">Getting started with Travis CI</a>
 </p>
 
 <p style="text-align:left;margin-bottom:4px">
-Questions? Issues? Comments? Please message us at  <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Closed%20Beta" style="color:#0068FF;"><%= @support_mail %></a>
+Questions? Issues? Comments? Please message us at  <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Support%20Request" style="color:#0068FF;"><%= @support_mail %></a>
 </p>
-
-<p style="font-weight:700;text-align:left;margin-bottom:30px">
-As a reminder, we will give a $100 Amazon gift card to each beta participant that provides us with feedback following their trial
-</p>
-
 
 <p style="text-align:left;color:#333333;">
 Thank you, and have a great day!
@@ -119,7 +114,7 @@ The Travis CI Team
               <tbody>
                 <tr>
                   <td style="padding:40px 0px 20px 0px;color:#0068ff;font-size:18px;font-weight:300;" valign="top" align="center">Have any questions?
-                    <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Closed%20Beta" style="color:#0068FF;">We're here to help.</a>
+                    <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Support%20Request" style="color:#0068FF;">We're here to help.</a>
                   </td>
                 </tr>
                 <tr>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -79,7 +79,7 @@ We recommend reading the <a href="https://docs.travis-ci.com/user/for-beginners/
               <tbody>
                 <tr>
                   <td style="padding:40px 0px 20px 0px;color:#0068ff;font-size:18px;font-weight:300;" valign="top" align="center">Have any questions?
-                    <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Closed%20Beta" style="color:#0068FF;">We're here to help.</a>
+                    <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Support%20Request" style="color:#0068FF;">We're here to help.</a>
                   </td>
                 </tr>
                 <tr>

--- a/app/views/invitation_mailer/send_invitation.html.erb
+++ b/app/views/invitation_mailer/send_invitation.html.erb
@@ -4,7 +4,7 @@
 
 <p style="text-align:left;">
 The Travis VCS Proxy user <%= @invited_by %> invited you to the Travis CI VCS Proxy organization <%=@organization%>. 
-Travis CI Version Control System (VCS)  Proxy allows you to connect Perforce Helix Core and Apache SVN repositories to Travis CI and benefit from CI/CD automation Travis CI offers.
+Travis CI "Version Control System (VCS) Proxy" allows you to connect Perforce Helix Core and Apache SVN repositories to Travis CI and benefit from CI/CD automation Travis CI offers.
 </p>
 
 <p style="margin-bottom:30px;text-align:left;color:#333333;">

--- a/app/views/invitation_mailer/send_invitation.text.erb
+++ b/app/views/invitation_mailer/send_invitation.text.erb
@@ -1,7 +1,7 @@
 Hello <%= @email %> !
 
 The Travis VCS Proxy user <%= @invited_by %> invited you to the Travis CI VCS Proxy organization <%=@organization%>. 
-Travis CI Version Control System (VCS)  Proxy allows you to connect Perforce Helix Core and Apache SVN repositories to Travis CI and benefit from CI/CD automation Travis CI offers.
+Travis CI "Version Control System (VCS) Proxy" allows you to connect Perforce Helix Core and Apache SVN repositories to Travis CI and benefit from CI/CD automation Travis CI offers.
 
 You must be logged in to Travis CI VCS Proxy to accept the invitation. If you already have an active Travis CI VCS Proxy account, please log in and follow this link:
 

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -49,7 +49,7 @@
               <tbody>
                 <tr>
                   <td style="padding:40px 0px 20px 0px;color:#0068ff;font-size:18px;font-weight:300;" valign="top" align="center">Have any questions?
-                    <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Closed%20Beta" style="color:#0068FF;">We're here to help.</a>
+                    <a href="mailto:<%= @support_mail %>?Subject=Travis%20CI%20VCS%20Proxy%20-%20Support%20Request" style="color:#0068FF;">We're here to help.</a>
                   </td>
                 </tr>
                 <tr>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,10 +2,10 @@ jwt:
   secret: fill-me
 otp_secret_encryption_key: 12391230-12e90-2if912d120s912is0921iw9012iw9012wi1290wi1290f139
 p4_token_encryption_key: HTmcYwLgONSdedIPBrUcsVQjJjQkFZBE
-web_url: https://travis-vcs-proxy.travis-ci.org
-api_url: https://travis-vcs-proxy-api.travis-ci.org
-travis_url: https://app.travis-ci.com
-support_mail: 'beta.support@travis-ci.com'
+web_url: https://vcs-proxy.travis-ci.com
+api_url: https://vcs-proxy-api.travis-ci.com
+travis_url: https://vcs-app.travis-ci.com
+support_mail: 'support@travis-ci.com'
 contact_mail: 'contact@travis-ci.com'
 feedback_mail: 'cancellations@travis-ci.com'
 mail_from: test@example.com


### PR DESCRIPTION
Removing 'beta' remarks from email templates and defaults in configuration